### PR TITLE
Allow PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,3 @@ jobs:
         - composer install
       script:
         - composer integrate
-    - name: PHP Nightly
-      php: nightly
-      before_script:
-        - composer remove friendsofphp/php-cs-fixer --no-update --dev
-        - composer require composer/composer "^2.0"
-      script:
-        - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,10 @@ jobs:
         - composer install
       script:
         - composer integrate
+    - name: PHP Nightly
+      php: nightly
+      before_script:
+        - composer remove friendsofphp/php-cs-fixer --no-update --dev
+        - composer require composer/composer "^2.0"
+      script:
+        - ./vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2020-11-22
 
-- Use `author['login']` in preference to `comitter['login]` (as github
+- Use `author['login']` in preference to `comitter['login']` (as github
   started using `web-flow` as the comitter user)
 
 ## [0.3.0] - 2020-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2020-11-22
+
+- Use `author['login']` in preference to `comitter['login]` (as github
+  started using `web-flow` as the comitter user)
+
 ## [0.3.0] - 2020-06-20
 
 - Support using the composer github oauth key.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
@@ -39,7 +39,7 @@
     "extra": {
         "class": "DTL\\WhatChanged\\WhatChangedPlugin",
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "0.5.x-dev"
         }
     },
     "scripts": {

--- a/lib/Adapter/Github/GithubChangelog.php
+++ b/lib/Adapter/Github/GithubChangelog.php
@@ -66,7 +66,7 @@ class GithubChangelog implements Changelog
             yield ChangeBuilder::create()
                 ->rawDate($commit['commit']['author']['date'])
                 ->message($commit['commit']['message'])
-                ->author($commit['committer']['login'] ?? '<???>')
+                ->author($commit['author']['login'] ?? $commit['committer']['login'] ?? '<???>')
                 ->parents($commit['parents'])
                 ->sha($commit['sha'])
                 ->build();


### PR DESCRIPTION
All github merges now have `web-flow` as the user (because it's now the `comitter`). This PR:

- Uses `['author']['login']` in preference to `['committer']['login']` (not sure why this was so originally - perhaps there was a reason :shrug: )