### PR TITLE
Fix strlenWithoutDecoration() is deprecated

### DIFF
--- a/lib/Adapter/Symfony/Report/ConsoleReport.php
+++ b/lib/Adapter/Symfony/Report/ConsoleReport.php
@@ -215,7 +215,7 @@ class ConsoleReport implements Report
     private function truncateToTerminalWidth(string $line)
     {
         $width = $this->terminalWidth();
-        $realLength = FormatterHelper::strlenWithoutDecoration($this->formatter, $line);
+        $realLength = FormatterHelper::width(FormatterHelper::removeDecoration($this->formatter, $line));
 
         if ($realLength > $width) {
             return mb_substr(


### PR DESCRIPTION
```
Deprecation Notice: Since symfony/console 5.3: Method "Symfony\Component\Console\Helper\Helper::strlenWithoutDecoration()" is deprecated and will be removed in Symfony 6.0. Use Helper::removeDecoration() instead
```