### PR TITLE
fix: remove implicitly nullable parameter types

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,6 +10,7 @@ return PhpCsFixer\Config::create()
         '@PSR2' => true,
         'no_unused_imports' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder($finder)
 ;

--- a/lib/Model/Output/BufferedReportOutput.php
+++ b/lib/Model/Output/BufferedReportOutput.php
@@ -13,7 +13,7 @@ class BufferedReportOutput implements ReportOutput
         $this->buffer .= $output;
     }
 
-    public function writeln(string $output = null)
+    public function writeln(?string $output = null)
     {
         $this->write($output . PHP_EOL);
     }

--- a/lib/Model/ReportOutput.php
+++ b/lib/Model/ReportOutput.php
@@ -5,5 +5,5 @@ namespace DTL\WhatChanged\Model;
 interface ReportOutput
 {
     public function write(string $output);
-    public function writeln(string $output = null);
+    public function writeln(?string $output = null);
 }


### PR DESCRIPTION
This PR removes [php deprecation for implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types).

```
Deprecation Notice: DTL\WhatChanged\Model\ReportOutput::writeln(): Implicitly marking parameter $output as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/dantleech/what-changed/lib/Model/ReportOutput.php:8
```